### PR TITLE
Added memosize param to TokenTransfer tx

### DIFF
--- a/src/resources/APIsAndUsage.json
+++ b/src/resources/APIsAndUsage.json
@@ -426,9 +426,8 @@
 			"info": "Send tokens (See CryptoTransfer for details).",
 			"status": "complete",
 			"isImportant": true,
-
 			"usage": {
-
+				"memoSize": 0
 			},
 			"formulae": {
 			


### PR DESCRIPTION
added a memosize param to 'Send tokens via CryptoTranfer" transaction to resolve bug where the price wasn't displaying