### PR TITLE
Restore base query price

### DIFF
--- a/src/calculator/Price.js
+++ b/src/calculator/Price.js
@@ -219,6 +219,12 @@ class Price {
             this.sumProduct(this.feeSchedules[api][apiType], actualUsage) /
             (this.model.FEE_SCHEDULE_MULTIPLIER * this.model.USD_TO_TINYCENTS)
         );
+        if (customApiParams.type === 'query') {
+            if (api !== 'CryptoGetAccountBalance' && api !== 'TransactionGetReceipt') {
+                // Incorporate price of CryptoTransfer used to pay node
+                this.normalizedPrice += 0.0001;
+            }
+        }
 
         return ({
             usage: actualUsage,

--- a/src/resources/typedFeeSchedules.json
+++ b/src/resources/typedFeeSchedules.json
@@ -834,7 +834,7 @@
   "TokenCreate": {
     "TOKEN_FUNGIBLE_COMMON_WITH_CUSTOM_FEES": {
       "node": {
-        "constant": 393746195920,
+        "constant": 452746195920,
         "bpt": 17485616,
         "vpt": 43714039850,
         "rbh": 11657,
@@ -872,7 +872,7 @@
     },
     "TOKEN_FUNGIBLE_COMMON": {
       "node": {
-        "constant": 197306974233,
+        "constant": 213306974233,
         "bpt": 8762076,
         "vpt": 21905189240,
         "rbh": 5841,
@@ -910,7 +910,7 @@
     },
     "TOKEN_NON_FUNGIBLE_UNIQUE": {
       "node": {
-        "constant": 197031853851,
+        "constant": 213031853851,
         "bpt": 8749858,
         "vpt": 21874645140,
         "rbh": 5833,
@@ -948,7 +948,7 @@
     },
     "TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES": {
       "node": {
-        "constant": 393198370765,
+        "constant": 452198370765,
         "bpt": 17461288,
         "vpt": 43653219832,
         "rbh": 11641,


### PR DESCRIPTION
**Description**:
- Restore the [$0.0001 query base price](https://github.com/hashgraph/hedera-fee-tool-js/blob/48010eb5c8457654adf4b571f671f8d122d79427/src/calculator/Price.js#L210) in _Price.js_.
- Bump node constants in `TokenCreate` variants so the base prices are exactly $1.00 w/o custom fees, $2.00 with.
